### PR TITLE
Depend on f500.php to find 'restart fpm' handler

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,3 +14,4 @@ galaxy_info:
     - web
 dependencies:
     - f500.repo_dotdeb
+    - f500.php


### PR DESCRIPTION
Ansible (now) requires includes or dependencies between roles to use eachothers' handlers