### PR TITLE
Add ability to write xdebug-config-without-activating-extension

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,3 +52,4 @@ php_xdebug_var_display_max_depth: 3
 
 # available: apache2, apache2filter, cgi, cli, fpm
 php_xdebug_versions: []
+php_xdebug_disabled_by_default_versions: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,22 +24,40 @@
 - name: write xdebug.ini
   template: src=xdebug.ini.j2 dest='{{ php_etc_dir }}/mods-available/xdebug.ini' owner=root group=root mode=0644
 
-- name: activate cli xdebug
+- name: write cli xdebug config
   file: src='{{ php_etc_dir }}/mods-available/xdebug.ini' dest='{{ php_etc_dir }}/cli/conf.d/20-xdebug.ini' state=link
   when: "'cli' in php_xdebug_versions"
 
-- name: deactivate cli xdebug
+- name: active cli xdebug
+  copy: content="zend_extension={{ php_xdebug_extension }}" dest='{{ php_etc_dir }}/cli/conf.d/21-xdebug.ini' owner=root group=root mode=0644
+  when: "'cli' not in php_xdebug_disabled_by_default_versions"
+
+- name: deactivate cli xdebug config
   file: path='{{ php_etc_dir }}/cli/conf.d/20-xdebug.ini' state=absent
   when: "'cli' not in php_xdebug_versions"
 
-- name: activate fpm xdebug
+- name: deactivate cli xdebug extension
+  file: path='{{ php_etc_dir }}/cli/conf.d/21-xdebug.ini' state=absent
+  when: "'cli' not in php_xdebug_versions or 'cli' in php_xdebug_disabled_by_default_versions"
+
+- name: write fpm xdebug config
   file: src='{{ php_etc_dir }}/mods-available/xdebug.ini' dest='{{ php_etc_dir }}/fpm/conf.d/20-xdebug.ini' state=link
   notify:
     - restart php-fpm
   when: "'fpm' in php_xdebug_versions"
+
+- name: active fms xdebug
+  copy: content="zend_extension={{ php_xdebug_extension }}" dest='{{ php_etc_dir }}/fpm/conf.d/21-xdebug.ini' owner=root group=root mode=0644
+  when: "'fpm' not in php_xdebug_disabled_by_default_versions"
 
 - name: deactivate fpm xdebug
   file: path='{{ php_etc_dir }}/fpm/conf.d/20-xdebug.ini' state=absent
   notify:
     - restart php-fpm
   when: "'fpm' not in php_xdebug_versions"
+
+- name: deactivate fpm xdebug
+  file: path='{{ php_etc_dir }}/fpm/conf.d/21-xdebug.ini' state=absent
+  notify:
+    - restart php-fpm
+  when: "'fpm' not in php_xdebug_versions or 'fpm' in php_xdebug_disabled_by_default_versions"

--- a/templates/xdebug.ini.j2
+++ b/templates/xdebug.ini.j2
@@ -1,5 +1,3 @@
-zend_extension={{ php_xdebug_extension }}
-
 [xdebug]
 xdebug.auto_trace = {{ php_xdebug_auto_trace }}
 xdebug.cli_color = {{ php_xdebug_cli_color }}


### PR DESCRIPTION
This PR allows for writing an xdebug config file without activating the module. It _will_ be activated by default but you can disable it for each service individually.

The benefit of this is that you might want to have xdebug ready on a local development environment, but not activated (because it slows down running of tests). You can still activate xdebug on the cli by adding `php -dzend_extension=xdebug.so ...`

(adding a bash alias for this is probably a good idea)